### PR TITLE
Revise Teaching Coordinator role description

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -103,7 +103,11 @@ The additional officers shall be:
 4.4.6 Teaching Coordinator
 4.4.6.a The Teaching Coordinator is responsible for curating a varied and relevant selection of topics to be covered in the regular teaching sessions.
 4.4.6.b The Teaching Coordinator should work alongside the Secretary and Media Officer to communicate the plan for the teaching sessions.
-4.4.6.c For each scheduled teaching session, the Teaching Coordinator is responsible for either leading the session or supporting another member of the society to lead it.
+4.4.6.c For each scheduled teaching session, the Teaching Coordinator is responsible for either leading the session or supporting another member of the society to lead it. If desired, this support should include:
+	(1) Reviewing prepared material such as slides in advance and giving helpful feedback.
+	(2) Planning the session and distributing resources such as slides.
+	(3) Coaching or preparing the session lead.
+	(4) Providing feedback at the end of the session to allow them to improve for future sessions.
 
 4.5 – Committee Roles
 4.5.1 – Committee Roles are intended to support the Executive Committee (Core Officers plus Additional Officers).

--- a/constitution.md
+++ b/constitution.md
@@ -103,7 +103,7 @@ The additional officers shall be:
 4.4.6 Teaching Coordinator
 4.4.6.a The Teaching Coordinator is responsible for curating an interesting selection of topics to be covered in the regular teaching sessions.
 4.4.6.b The Teaching Coordinator should work alongside the Secretary and Media Officer to communicate the plan for the teaching sessions.
-4.4.6.c Every week, the Teaching Coordinator is responsible for either leading the session or supporting another member of the society to lead it.
+4.4.6.c For each scheduled teaching session, the Teaching Coordinator is responsible for either leading the session or supporting another member of the society to lead it.
 
 4.5 – Committee Roles
 4.5.1 – Committee Roles are intended to support the Executive Committee (Core Officers plus Additional Officers).

--- a/constitution.md
+++ b/constitution.md
@@ -101,11 +101,9 @@ The additional officers shall be:
 4.4.5.c The Careers Officer should work alongside the Media Officer to ensure members are informed about the roles that are available in the Games Industry.
 
 4.4.6 Teaching Coordinator
-4.4.6.a The Teaching Coordinator is responsible for planning the topics to be covered in the regular teaching sessions.
+4.4.6.a The Teaching Coordinator is responsible for curating an interesting selection of topics to be covered in the regular teaching sessions.
 4.4.6.b The Teaching Coordinator should work alongside the Secretary and Media Officer to communicate the plan for the teaching sessions.
-4.4.6.c The Teaching Coordinator should conduct the majority of the teaching sessions.
-4.4.6.d In the event that the Teaching Coordinator is unable to lead a teaching session, they are responsible for distributing all relevant resources to allow another society member to lead the session.
-
+4.4.6.c Every week, the Teaching Coordinator is responsible for either leading the session or supporting another member of the society to lead it.
 
 4.5 – Committee Roles
 4.5.1 – Committee Roles are intended to support the Executive Committee (Core Officers plus Additional Officers).

--- a/constitution.md
+++ b/constitution.md
@@ -101,7 +101,7 @@ The additional officers shall be:
 4.4.5.c The Careers Officer should work alongside the Media Officer to ensure members are informed about the roles that are available in the Games Industry.
 
 4.4.6 Teaching Coordinator
-4.4.6.a The Teaching Coordinator is responsible for curating an interesting selection of topics to be covered in the regular teaching sessions.
+4.4.6.a The Teaching Coordinator is responsible for curating a varied and relevant selection of topics to be covered in the regular teaching sessions.
 4.4.6.b The Teaching Coordinator should work alongside the Secretary and Media Officer to communicate the plan for the teaching sessions.
 4.4.6.c For each scheduled teaching session, the Teaching Coordinator is responsible for either leading the session or supporting another member of the society to lead it.
 


### PR DESCRIPTION
Remove the requirement to run the majority of the sessions. Add clarity that the role of the teaching coordinator is to either lead the sessions or to support other exec, whether that is distributing resources or helping to develop other people's teaching skills in other ways.